### PR TITLE
feat: integrate Chronoquest services into Otterverse stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ ChronoQuest is an engaging and educational historical knowledge game where playe
    npm start
    ```
 
+## Integration with OtterVerse
+ChronoQuest is now integrated into the OtterVerse platform as one of its modular services. When deployed as part of OtterVerse, ChronoQuest runs as a separate Docker Compose stack and communicates via a shared external network (named `otterverse-net`). In this setup, the ChronoQuest frontend is accessible via the network alias `chronoquest-frontend`. For complete deployment instructions and to see how ChronoQuest interacts with the other services, please refer to the OtterVerse documentation.
+
+
 ## Contribution
 Contributions are welcome! Please submit issues and pull requests to help improve the game.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,37 +11,46 @@ services:
       - db_data:/var/lib/postgresql/data
     restart: unless-stopped
 
+
   backend:
     build:
-      context: .  # Use the root directory as the build context
+      context: .
       dockerfile: backend/Dockerfile
     ports:
       - "5000:5000"
     volumes:
       - ./backend:/app
-      - ./shared:/app/shared  # Mount shared folder
+      - ./shared:/app/shared
       - /app/node_modules
     environment:
       - NODE_ENV=development
-      # Use a connection string that points to the “db” service
-      - DATABASE_URL=postgres://user:password@db:5432/chronoquest
-    depends_on:
-      - db
     restart: unless-stopped
+    networks:
+      otterverse-net:
+        aliases:
+          - chronoquest-backend
 
   frontend:
     build:
-      context: .  # Use the root directory as the build context
+      context: .
       dockerfile: frontend/Dockerfile
     ports:
       - "4173:4173"
     volumes:
       - ./frontend:/app
-      - ./shared:/app/shared  # Mount shared folder
+      - ./shared:/app/shared
       - /app/node_modules
     environment:
       - NODE_ENV=development
     restart: unless-stopped
+    networks:
+      otterverse-net:
+        aliases:
+          - chronoquest-frontend
+
+networks:
+  otterverse-net:
+    external: true
 
 volumes:
   db_data:

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -10,6 +10,10 @@ export default defineConfig({
   preview: {
     port: 4173, // Port for the preview server
     host: true, // Expose the preview server to all network interfaces
+    allowedHosts: [
+      'chronoquest-frontend',
+      'chronoquest-backend'
+    ] // Allow this hostname in the preview server
   },
   build: {
     outDir: 'dist', // Output directory for the production build


### PR DESCRIPTION
- Updated Chronoquest docker-compose with network aliases (chronoquest-frontend and chronoquest-backend).
- Adjusted Vite preview configuration to allow the 'chronoquest-frontend' host.
- Update README.md