### PR TITLE
fix: Vite build cache issue in Docker

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,21 +2,23 @@ FROM node:18
 
 WORKDIR /app
 
-# Copy package.json and package-lock.json from the frontend directory
+# Copy package.json first to optimize caching
 COPY frontend/package*.json ./
 
-# Install dependencies
 RUN npm install
 
-# Copy the rest of the frontend files
+# Copy the frontend source code
 COPY frontend/ ./
 
-# Copy the shared folder
+# Copy shared folder
 COPY shared /app/shared
 
-# Build the project
+# 🚨 Fix: Delete old builds automatically on container start
+RUN rm -rf dist node_modules/.vite
+
+# Run Vite build before starting the server
 RUN npm run build
 
 EXPOSE 4173
 
-CMD ["npm", "run", "preview"]
+CMD ["sh", "-c", "rm -rf dist node_modules/.vite && npm run build && npm run preview"]


### PR DESCRIPTION
- Ensure `dist/` and `node_modules/.vite` are removed before building
- Modify Dockerfile to automate cleanup and force fresh builds
- Prevent old Vite builds from being served inside the container
- Now, changes always reflect on `docker-compose up` without manual steps
