### PR TITLE
feat: add correctness border for cards

### DIFF
--- a/frontend/src/components/Card.css
+++ b/frontend/src/components/Card.css
@@ -11,7 +11,7 @@
   height: 100%;
   position: absolute;
   transform-style: preserve-3d;
-  transition: transform 0.6s;
+  transition: transform 0.6s ease-in-out;
 }
 
 .card.flipped .card-inner {
@@ -63,4 +63,12 @@
   text-overflow: ellipsis;
   white-space: normal;
   font-size: 14px;
+}
+
+.correct-position {
+  border: 4px solid #28a745;
+}
+
+.false-position {
+  border: 4px solid #dc3545;
 }

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -7,9 +7,12 @@ interface CardProps {
   index: number;
   moveCard: (dragIndex: number, hoverIndex: number) => void;
   flipped: boolean;
+  submitted: boolean;
+  cardResults: Record<number, boolean>;
 }
 
-const Card: React.FC<CardProps> = ({ event, index, moveCard, flipped }) => {
+
+const Card: React.FC<CardProps> = ({ event, index, moveCard, flipped, cardResults, submitted }) => {
   const ref = useRef<HTMLDivElement>(null);
 
   const [, drop] = useDrop({
@@ -33,12 +36,16 @@ const Card: React.FC<CardProps> = ({ event, index, moveCard, flipped }) => {
   drag(drop(ref));
 
   return (
-    <div ref={ref} className={`card ${flipped ? "flipped" : ""}`} style={{ opacity: isDragging ? 0.5 : 1 }}>
-      <div className="card-inner">
-        <div className="card-front">
+    <div
+      ref={ref}
+      className={`card ${flipped ? "flipped" : ""}`}
+      style={{ opacity: isDragging ? 0.5 : 1 }}
+    >
+      <div className={`card-inner`}>
+        <div className={`card-front ${submitted ? (cardResults[event.id] ? "correct-position" : "false-position") : ""}`}>
           <p>{event.name} <br />({event.date.split("-")[0]})</p>
         </div>
-        <div className="card-back">
+        <div className={`card-back ${submitted ? (cardResults[event.id] ? "correct-position" : "false-position") : ""}`}>
           <div className="card-content">
             <p className="truncate-text">{event.imageurl}</p>
             <hr />

--- a/frontend/src/components/GameBoard.tsx
+++ b/frontend/src/components/GameBoard.tsx
@@ -16,6 +16,7 @@ const GameBoard: React.FC = () => {
   const [isCorrect, setIsCorrect] = useState<boolean | null>(null);
   const [modalOpen, setModalOpen] = useState<boolean>(false);
   const [submitted, setSubmitted] = useState<boolean>(false);
+  const [cardResults, setCardResults] = useState<Record<number, boolean>>({});
   const [showTooltip, setShowTooltip] = useState<boolean>(false);
   const [flippedCards, setFlippedCards] = useState<boolean>(false);
 
@@ -40,11 +41,11 @@ const GameBoard: React.FC = () => {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(events),
       });
-
+  
       if (!response.ok) {
         throw new Error("Failed to submit order");
       }
-
+  
       const result = await response.json();
       setScore(result.score);
       setCorrectOrder(result.correctOrder);
@@ -52,6 +53,12 @@ const GameBoard: React.FC = () => {
       setSubmitted(true);
       setModalOpen(true);
       setScoreMessage(getScoreMessage(result.score));
+  
+      const correctnessMap: Record<number, boolean> = {};
+      events.forEach((event, index) => {
+        correctnessMap[event.id] = result.correctOrder[index] === event.id;
+      });
+      setCardResults(correctnessMap);
     } catch (error) {
       console.error("Error submitting order:", error);
     }
@@ -67,6 +74,8 @@ const GameBoard: React.FC = () => {
         )
       );
 
+      setFlippedCards(false);
+
       // Flip cards after a short delay
       setTimeout(() => {
         setFlippedCards(true);
@@ -80,7 +89,15 @@ const GameBoard: React.FC = () => {
         {/* Row 1: Cards */}
         <div className="game-board">
           {events.map((event, index) => (
-            <Card key={event.id} event={event} index={index} moveCard={moveCard} flipped={flippedCards} />
+            <Card 
+              key={event.id} 
+              event={event} 
+              index={index} 
+              moveCard={moveCard} 
+              flipped={flippedCards} 
+              cardResults={cardResults} 
+              submitted={submitted}  
+            />
           ))}
         </div>
 


### PR DESCRIPTION
- Added green border for correctly placed cards and red for incorrect ones
- Applied correctness check only after submission to prevent premature styling
- Ensured color persists after modal close
- Fixed issue where flipping reset border color by applying styles to both front and back
- Improved state handling to avoid unnecessary re-renders