### PR TITLE
feat: Lock card order after solution is shown

### DIFF
--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -28,6 +28,7 @@ const Card: React.FC<CardProps> = ({ event, index, moveCard, flipped, cardResult
   const [{ isDragging }, drag] = useDrag({
     type: "CARD",
     item: { index },
+    canDrag: !submitted,
     collect: (monitor) => ({
       isDragging: monitor.isDragging(),
     }),

--- a/frontend/src/components/GameBoard.tsx
+++ b/frontend/src/components/GameBoard.tsx
@@ -28,6 +28,8 @@ const GameBoard: React.FC = () => {
   }, []);
 
   const moveCard = (dragIndex: number, hoverIndex: number) => {
+    if (submitted) return;
+    
     const updatedEvents = [...events];
     const [removed] = updatedEvents.splice(dragIndex, 1);
     updatedEvents.splice(hoverIndex, 0, removed);


### PR DESCRIPTION
- Disabled dragging after submission to prevent reordering
- Updated  to check  state before allowing drag
- Added  class for visual feedback
- Ensured  function is blocked post-submission