### PR TITLE
feat: Implement game attempt limitation and CORS fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 .dockerignore
 **/.dockerignore
 .vscode/
+backend/cookies.txt

--- a/README.md
+++ b/README.md
@@ -67,13 +67,16 @@ docker-compose up -d
 ```
 
 #### **Step 2: Apply Migrations**
-Since the database is empty, you must apply migrations to recreate the `events` table:
-```sh
-docker exec -it $(docker ps -qf "name=backend") sh -c 'PGPASSWORD="$POSTGRES_PASSWORD" psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -h db -f /app/migrations/001-create-events.sql'
-```
+Since the database is empty, you must apply **all migrations** to recreate the required tables.
 
+Run the following command to apply all migrations in the `migrations/` folder:
+```sh
+docker exec -it $(docker ps -qf "name=backend") sh -c 'PGPASSWORD="$POSTGRES_PASSWORD" psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -h db -f <(cat /app/migrations/*.sql)'
+```
 This will:
-- Ensure the `events` table exists before inserting data.
+
+- Ensure **all necessary tables** are created before inserting data.
+- Apply any **new migrations automatically**.
 
 #### **Step 3: Verify Migrations Were Applied**
 To check if the table was created, run:

--- a/backend/migrations/002-add-game-attempts.sql
+++ b/backend/migrations/002-add-game-attempts.sql
@@ -1,0 +1,7 @@
+-- Create the game_attempts table to track daily plays
+CREATE TABLE game_attempts (
+    id SERIAL PRIMARY KEY,
+    guest_id TEXT NOT NULL,
+    attempt_date DATE NOT NULL DEFAULT CURRENT_DATE,
+    UNIQUE (guest_id, attempt_date)
+);

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -8,16 +8,20 @@
       "name": "backend",
       "version": "1.0.0",
       "dependencies": {
+        "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "dayjs": "^1.11.13",
         "express": "^4.18.2",
-        "pg": "^8.13.3"
+        "pg": "^8.13.3",
+        "uuid": "^11.1.0"
       },
       "devDependencies": {
+        "@types/cookie-parser": "^1.4.8",
         "@types/cors": "^2.8.17",
-        "@types/express": "^4.17.17",
+        "@types/express": "^4.17.21",
         "@types/node": "^20.10.0",
         "@types/pg": "^8.11.11",
+        "@types/uuid": "^10.0.0",
         "nodemon": "^3.0.2",
         "ts-node": "^10.9.1",
         "typescript": "^5.7.3"
@@ -111,6 +115,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cookie-parser": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.8.tgz",
+      "integrity": "sha512-l37JqFrOJ9yQfRQkljb41l0xVphc7kg5JTjjr+pLRZ0IyZ49V4BQ8vbF4Ut2C2e+WH4al3xD3ZwYwIUfnbT4NQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/express": "*"
       }
     },
     "node_modules/@types/cors": {
@@ -283,6 +297,13 @@
         "@types/node": "*",
         "@types/send": "*"
       }
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -513,6 +534,28 @@
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
       "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -1773,6 +1816,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,16 +9,20 @@
     "seed": "ts-node src/seed.ts"
   },
   "dependencies": {
+    "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "dayjs": "^1.11.13",
     "express": "^4.18.2",
-    "pg": "^8.13.3"
+    "pg": "^8.13.3",
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
+    "@types/cookie-parser": "^1.4.8",
     "@types/cors": "^2.8.17",
-    "@types/express": "^4.17.17",
+    "@types/express": "^4.17.21",
     "@types/node": "^20.10.0",
     "@types/pg": "^8.11.11",
+    "@types/uuid": "^10.0.0",
     "nodemon": "^3.0.2",
     "ts-node": "^10.9.1",
     "typescript": "^5.7.3"

--- a/backend/src/game_config/gameConfig.ts
+++ b/backend/src/game_config/gameConfig.ts
@@ -11,7 +11,9 @@ export const gameConfig = {
   },
   baseScoreCoefficient: 100,
   sameDateModeDefault: false,
+  oneGamePerDayMode: false,
   levelDefault: 'beginner',
+  httpsOn: false,
 };
 
 export type Level = keyof typeof gameConfig.numCardsPerLevel;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,20 +1,35 @@
 import express from "express";
 import cors from "cors";
+import cookieParser from "cookie-parser";
 import eventRoutes from "./routes/events";
+import gameAttemptsRoutes from "./routes/gameAttempts";
 
 const app = express();
 
 // Enable CORS for frontend requests
-app.use(cors());
+const allowedOrigins = ["http://localhost:4173", "http://localhost:5173"];
+
+app.use(cors({
+    origin: function (origin, callback) {
+        if (!origin || allowedOrigins.includes(origin)) {
+            callback(null, true);
+        } else {
+            callback(new Error("Not allowed by CORS"));
+        }
+    },
+    credentials: true // ⬅️ Allow cookies and authentication headers
+}));
 app.use(express.json());
+app.use(cookieParser());
 
 // Root route
-app.get('/', (req, res) => {
-  res.send('Welcome to the ChronoQuest Backend API');
+app.get("/", (req, res) => {
+  res.send("Welcome to the ChronoQuest Backend API");
 });
 
-// Register the existing events route
-app.use("/events", eventRoutes);
+// Register routes
+app.use("/api/events", eventRoutes);
+app.use("/api/game", gameAttemptsRoutes);
 
 const port = process.env.PORT || 5000;
 app.listen(port, () => {

--- a/backend/src/routes/gameAttempts.ts
+++ b/backend/src/routes/gameAttempts.ts
@@ -1,0 +1,70 @@
+import express from "express";
+import { Request, Response, NextFunction } from "express";
+import { gameConfig } from "../game_config/gameConfig";
+import pool from '../db';
+import { v4 as uuidv4 } from "uuid";
+import { log } from "console";
+
+const router = express.Router();
+
+/**
+ * Get or create a unique guest ID
+ */
+async function getOrCreateGuestId(req: Request, res: Response) {
+    let guestId = req.cookies?.guest_id;
+
+    if (!guestId) {
+        console.log("Generating new guest ID...");
+        guestId = uuidv4();
+        res.cookie("guest_id", guestId, {
+            httpOnly: true,
+            secure: gameConfig.httpsOn? true : false,
+            sameSite: "strict",
+            path: "/"
+        });
+    }
+
+    return guestId;
+}
+
+/**
+ * Middleware to check if the player has already played today
+ */
+async function canPlayToday(req: Request, res: Response, next: NextFunction) {
+    if (!gameConfig.oneGamePerDayMode) { // ⬅️ Bypass restriction if disabled
+        console.log("One game per day mode is OFF. Skipping check.");
+        return next();
+    }
+
+    const guestId = await getOrCreateGuestId(req, res);
+
+    const result = await pool.query(
+        `SELECT COUNT(*) FROM game_attempts WHERE guest_id = $1 AND attempt_date = CURRENT_DATE`,
+        [guestId]
+    );
+
+    const playCount = parseInt(result.rows[0].count, 10);
+    
+    if (playCount !== 0) {
+        return res.status(403).json({ message: "You have already played today! Come back tomorrow." });
+    }
+
+    next();
+}
+
+/**
+ * Record a new game attempt
+ */
+router.post("/start", canPlayToday, async (req, res) => {
+    const guestId = await getOrCreateGuestId(req, res);
+
+    if (gameConfig.oneGamePerDayMode) {
+        await pool.query(`INSERT INTO game_attempts (guest_id) VALUES ($1)`, [guestId]);
+    } else {
+        console.log("Skipping game attempt logging since oneGamePerDayMode is OFF.");
+    }
+
+    res.json({ message: "Game started!" });
+});
+
+export default router;

--- a/frontend/src/components/GameBoard.tsx
+++ b/frontend/src/components/GameBoard.tsx
@@ -23,21 +23,45 @@ const GameBoard: React.FC = () => {
   const [flippedCards, setFlippedCards] = useState<boolean>(false);
   const [showCards, setShowCards] = useState<boolean>(false);
   const [loading, setLoading] = useState<boolean>(true);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [finalMessage, setFinalMessage] = useState("");
 
+  // 🔹 Check if the player is allowed to play today
   useEffect(() => {
-    fetch("http://localhost:5000/events")
-      .then((response) => response.json())
-      .then((data) => {
-        setEvents(data);
+    const checkGameAvailability = async () => {
+      try {
+        const response = await fetch("http://localhost:5000/api/game/start", {
+          method: "POST",
+          credentials: "include",
+        });
+
+        const data = await response.json();
+        
+        if (response.status === 403) {
+          setErrorMessage(data.message);
+          setLoading(false);
+          return;
+        }
+
+        // ✅ If allowed to play, fetch events
+        const eventsResponse = await fetch("http://localhost:5000/api/events");
+        const eventsData = await eventsResponse.json();
+        setEvents(eventsData);
         setTimeout(() => {
           setShowCards(true);
           setLoading(false);
         }, 800);
-      })
-      .catch((error) => console.error("Fetch error:", error));
+      } catch (error) {
+        console.error("Error:", error);
+        setErrorMessage("Something went wrong. Please try again.");
+        setLoading(false);
+      }
+    };
+
+    checkGameAvailability();
   }, []);
 
+  // 🔹 Drag and drop functionality
   const moveCard = (dragIndex: number, hoverIndex: number) => {
     if (submitted) return;
 
@@ -47,9 +71,10 @@ const GameBoard: React.FC = () => {
     setEvents(updatedEvents);
   };
 
+  // 🔹 Submit order to check correctness
   const submitOrder = async () => {
     try {
-      const response = await fetch("http://localhost:5000/events/validate_order", {
+      const response = await fetch("http://localhost:5000/api/events/validate_order", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(events),
@@ -94,14 +119,18 @@ const GameBoard: React.FC = () => {
     }, 300);
 
     setFinalMessage(`${scoreMessage[0]}... You scored ${score} points. See you tomorrow!`);
-
   };
 
   return (
     <DndProvider backend={HTML5Backend}>
       <div className="game-board-container">
         {loading ? (
-            <div className="loading-spinner"></div>
+          <div className="loading-spinner"></div>
+        ) : errorMessage ? (
+          <div className="error-message">
+            <h2>History unfolds one day at a time! Return tomorrow for new events from the past.</h2>
+            <p>Come back tomorrow to play again!</p>
+          </div>
         ) : (
           <>
             {!submitted && <h2>Reorder the Events</h2>}
@@ -166,7 +195,7 @@ const GameBoard: React.FC = () => {
         </div>
       </Modal>
     </DndProvider>
-  );
+  );  
 };
 
 export default GameBoard;


### PR DESCRIPTION
- Added one-game-per-day mode with configurable bypass in gameConfig.ts.
- Integrated gameAttempts.ts for tracking game plays.
- Updated CORS settings to allow multiple frontend origins (localhost:4173, localhost:5173).
- Updated README.md to improve migration instructions.
- Fixed cookie handling for guest IDs in gameAttempts.ts.
- Refactored frontend (GameBoard.tsx) to check if the player is allowed to play.
- Updated API routes to use /api/events and /api/game/start.