### PR TITLE
feat: add difficulty mode and support for riddles

### DIFF
--- a/backend/src/game_config/gameConfig.ts
+++ b/backend/src/game_config/gameConfig.ts
@@ -7,7 +7,7 @@ export const gameConfig = {
   baseScoreCoefficient: 100,
   sameDateModeDefault: false,
   oneGamePerDayMode: false,
-  levelDefault: 'easy',
+  levelDefault: 'difficult',
   httpsOn: false,
 };
 

--- a/backend/src/routes/events.ts
+++ b/backend/src/routes/events.ts
@@ -33,7 +33,7 @@ router.get('/', async (req, res) => {
     }
 
     const result = await pool.query(query, params);
-    res.json(result.rows);
+    res.json({ level, events: result.rows });
   } catch (error) {
     console.error('Error fetching events:', error);
     res.status(500).json({ error: 'Failed to fetch events' });

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -3,16 +3,17 @@ import { useDrag, useDrop } from "react-dnd";
 import "./Card.css";
 
 interface CardProps {
-  event: { id: number; name: string; date: string; description: string; imageurl: string };
+  event: { id: number; name: string; date: string; description: string; imageurl: string; riddle: string; wikipediaUrl: string };
   index: number;
   moveCard: (dragIndex: number, hoverIndex: number) => void;
   flipped: boolean;
   submitted: boolean;
   cardResults: Record<number, boolean>;
+  difficulty: string;
 }
 
 
-const Card: React.FC<CardProps> = ({ event, index, moveCard, flipped, cardResults, submitted }) => {
+const Card: React.FC<CardProps> = ({ event, index, moveCard, flipped, cardResults, submitted, difficulty }) => {
   const ref = useRef<HTMLDivElement>(null);
 
   const [, drop] = useDrop({
@@ -44,8 +45,7 @@ const Card: React.FC<CardProps> = ({ event, index, moveCard, flipped, cardResult
     >
       <div className={`card-inner`}>
         <div className={`card-front ${submitted ? (cardResults[event.id] ? "correct-position" : "false-position") : ""}`}>
-          <div className={`event-name`}>{event.name}</div>
-          <div className={`event-hint`}>({event.date.split("-")[0]})</div>
+          <div className={`event-name`}>{difficulty === 'easy' ? event.name : event.riddle}</div>
         </div>
         <div className={`card-back ${submitted ? (cardResults[event.id] ? "correct-position" : "false-position") : ""}`}>
           <div className="card-content">

--- a/frontend/src/components/GameBoard.tsx
+++ b/frontend/src/components/GameBoard.tsx
@@ -9,7 +9,7 @@ import "./GameBoard.css";
 Modal.setAppElement("#root");
 
 const GameBoard: React.FC = () => {
-  const [events, setEvents] = useState<{ id: number; name: string; date: string; description: string; imageurl: string }[]>(
+  const [events, setEvents] = useState<{ id: number; name: string; date: string; description: string; imageurl: string; riddle: string; wikipediaUrl: string }[]>(
     []
   );
   const [score, setScore] = useState<number | null>(null);
@@ -22,6 +22,8 @@ const GameBoard: React.FC = () => {
   const [showTooltip, setShowTooltip] = useState<boolean>(false);
   const [flippedCards, setFlippedCards] = useState<boolean>(false);
   const [showCards, setShowCards] = useState<boolean>(false);
+  const [difficulty, setDifficulty] = useState<string>("");
+  // const [hintUsed, setHintUsed] = useState<boolean>(false);
   const [loading, setLoading] = useState<boolean>(true);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [finalMessage, setFinalMessage] = useState("");
@@ -35,18 +37,19 @@ const GameBoard: React.FC = () => {
           credentials: "include",
         });
 
-        const data = await response.json();
+        const check = await response.json();
         
         if (response.status === 403) {
-          setErrorMessage(data.message);
+          setErrorMessage(check.message);
           setLoading(false);
           return;
         }
 
         // ✅ If allowed to play, fetch events
         const eventsResponse = await fetch("http://localhost:5000/api/events");
-        const eventsData = await eventsResponse.json();
-        setEvents(eventsData);
+        const data = await eventsResponse.json();
+        setEvents(data.events);
+        setDifficulty(data.level);
         setTimeout(() => {
           setShowCards(true);
           setLoading(false);
@@ -133,7 +136,7 @@ const GameBoard: React.FC = () => {
           </div>
         ) : (
           <>
-            {!submitted && <h2>Reorder the Events</h2>}
+            {!submitted && <h2>Reorder the Events described on the cards</h2>}
             {submitted && !modalOpen && finalMessage && <h2>{finalMessage}</h2>}
             <div className="game-board">
               {showCards &&
@@ -146,6 +149,7 @@ const GameBoard: React.FC = () => {
                     flipped={flippedCards}
                     cardResults={cardResults}
                     submitted={submitted}
+                    difficulty={difficulty} 
                   />
                 ))}
             </div>


### PR DESCRIPTION
- Added difficulty levels ('easy', 'difficult') to backend and frontend.
- Updated API to return difficulty level along with events.
- Modified GameBoard.tsx to sync difficulty with backend response.
- Updated Card.tsx to display riddles in 'difficult' mode and event names in 'easy' mode.
- Changed heading to 'Reorder the events with the cards' for clarity.