### PR TITLE
feat: add easy/hard toggle and rename 'difficult' to 'hard'

### DIFF
--- a/backend/src/game_config/gameConfig.ts
+++ b/backend/src/game_config/gameConfig.ts
@@ -1,14 +1,14 @@
 export const gameConfig = {
   difficultyMultiplier: {
     easy: 1.0,
-    difficult: 2.0,
+    hard: 2.0,
   },
   numCards: 5,
   baseScoreCoefficient: 100,
   sameDateModeDefault: false,
   oneGamePerDayMode: false,
-  levelDefault: 'difficult',
+  levelDefault: 'easy',
   httpsOn: false,
 };
 
-export type Level = "easy" | "difficult";
+export type Level = "easy" | "hard";

--- a/backend/src/routes/events.ts
+++ b/backend/src/routes/events.ts
@@ -7,7 +7,7 @@ import { gameConfig, Level } from '../game_config/gameConfig';
 const router = Router();
 
 router.get('/', async (req, res) => {
-  const level = (req.query.level === "easy" || req.query.level === "difficult") ? (req.query.level as Level) : gameConfig.levelDefault;
+  const level = (req.query.level === "easy" || req.query.level === "hard") ? (req.query.level as Level) : gameConfig.levelDefault;
 
 
   // Get `sameDateMode` from query, but use default if not present
@@ -64,7 +64,7 @@ router.post('/validate_order', async (req, res) => {
     return res.status(400).json({ error: 'Invalid submission. Must provide an array of event objects.' });
   }
 
-  if (level !== "easy" && level !== "difficult") {
+  if (level !== "easy" && level !== "hard") {
     return res.status(400).json({ error: 'Invalid difficulty level.' });
   }
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -37,3 +37,15 @@
 .read-the-docs {
   color: #888;
 }
+
+button {
+  border-radius: 8px;
+  border: 1px solid transparent;
+  padding: 0.6em 1.2em;
+  font-size: 1.2em;
+  font-weight: 500;
+  font-family: inherit;
+  background-color: #535bf2;
+  cursor: pointer;
+  transition: border-color 0.25s;
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,11 +1,40 @@
+// src/App.tsx
+import { useState } from "react";
 import GameBoard from "./components/GameBoard";
 import "./App.css";
+import ToggleSwitch from "./components/ToggleSwitch";
 
 function App() {
+  const [difficulty, setDifficulty] = useState<"easy" | "hard">("easy");
+  const [showGameBoard, setShowGameBoard] = useState(false);
+
+  const handleToggle = () => {
+    setDifficulty((prev) => (prev === "easy" ? "hard" : "easy"));
+  };
+
+  const handleStartGame = () => {
+    setShowGameBoard(true);
+  };
+
   return (
     <div className="app">
       <h1>ChronoQuest</h1>
-      <GameBoard />
+
+      {!showGameBoard && (
+        <div style={{ marginBottom: "20px" }}>
+          <ToggleSwitch
+            isChecked={difficulty === "hard"}
+            onToggle={handleToggle}
+            label={difficulty === "hard" ? "Hard Mode" : "Easy Mode"}
+          />
+
+          <div style={{ marginTop: "30px" }}>
+            <button onClick={handleStartGame}>Start Game</button>
+          </div>
+        </div>
+      )}
+
+      {showGameBoard && <GameBoard difficulty={difficulty} />}
     </div>
   );
 }

--- a/frontend/src/components/GameBoard.css
+++ b/frontend/src/components/GameBoard.css
@@ -150,3 +150,14 @@
     transform: rotate(360deg);
   }
 }
+
+.difficulty-indicator {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  color: #fff;
+  font-weight: bold;
+  background: rgba(0, 0, 0, 0.4);
+  padding: 6px 12px;
+  border-radius: 8px;
+}

--- a/frontend/src/components/GameBoard.tsx
+++ b/frontend/src/components/GameBoard.tsx
@@ -1,3 +1,4 @@
+// src/components/GameBoard.tsx
 import { useState, useEffect } from "react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
@@ -8,10 +9,20 @@ import "./GameBoard.css";
 
 Modal.setAppElement("#root");
 
-const GameBoard: React.FC = () => {
-  const [events, setEvents] = useState<{ id: number; name: string; date: string; description: string; imageurl: string; riddle: string; wikipediaUrl: string }[]>(
-    []
-  );
+type GameBoardProps = {
+  difficulty: "easy" | "hard"; // Receive from parent
+};
+
+const GameBoard: React.FC<GameBoardProps> = ({ difficulty }) => {
+  const [events, setEvents] = useState<Array<{
+    id: number;
+    name: string;
+    date: string;
+    description: string;
+    imageurl: string;
+    riddle: string;
+    wikipediaUrl: string;
+  }>>([]);
   const [score, setScore] = useState<number | null>(null);
   const [scoreMessage, setScoreMessage] = useState<string[]>(["Processing your results..."]);
   const [correctOrder, setCorrectOrder] = useState<number[]>([]);
@@ -22,34 +33,37 @@ const GameBoard: React.FC = () => {
   const [showTooltip, setShowTooltip] = useState<boolean>(false);
   const [flippedCards, setFlippedCards] = useState<boolean>(false);
   const [showCards, setShowCards] = useState<boolean>(false);
-  const [difficulty, setDifficulty] = useState<string>("");
-  // const [hintUsed, setHintUsed] = useState<boolean>(false);
   const [loading, setLoading] = useState<boolean>(true);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [finalMessage, setFinalMessage] = useState("");
 
-  // 🔹 Check if the player is allowed to play today
+  // 🔹 Check if the player is allowed to play today and fetch events
   useEffect(() => {
     const checkGameAvailability = async () => {
       try {
+        // Optionally pass difficulty to your server if needed
         const response = await fetch("http://localhost:5000/api/game/start", {
           method: "POST",
           credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ difficulty }),
         });
 
         const check = await response.json();
-        
+
+        // If the server says we've already played, show an error
         if (response.status === 403) {
           setErrorMessage(check.message);
           setLoading(false);
           return;
         }
 
-        // ✅ If allowed to play, fetch events
+        // If allowed, fetch the actual events
         const eventsResponse = await fetch("http://localhost:5000/api/events");
         const data = await eventsResponse.json();
+        // We'll no longer setDifficulty from the server response
         setEvents(data.events);
-        setDifficulty(data.level);
+
         setTimeout(() => {
           setShowCards(true);
           setLoading(false);
@@ -62,19 +76,18 @@ const GameBoard: React.FC = () => {
     };
 
     checkGameAvailability();
-  }, []);
+  }, [difficulty]);
 
-  // 🔹 Drag and drop functionality
+  // 🔹 Drag and drop move
   const moveCard = (dragIndex: number, hoverIndex: number) => {
     if (submitted) return;
-
     const updatedEvents = [...events];
     const [removed] = updatedEvents.splice(dragIndex, 1);
     updatedEvents.splice(hoverIndex, 0, removed);
     setEvents(updatedEvents);
   };
 
-  // 🔹 Submit order to check correctness
+  // 🔹 Submit to check correctness
   const submitOrder = async () => {
     try {
       const response = await fetch("http://localhost:5000/api/events/validate_order", {
@@ -100,33 +113,33 @@ const GameBoard: React.FC = () => {
         correctnessMap[event.id] = result.correctOrder[index] === event.id;
       });
       setCardResults(correctnessMap);
+
     } catch (error) {
       console.error("Error submitting order:", error);
     }
   };
 
+  // 🔹 Close modal
   const closeModal = () => {
     setModalOpen(false);
-
     setTimeout(() => {
       setEvents((prevEvents) =>
-        correctOrder.map((id: number) => prevEvents.find((e: { id: number }) => e.id === id)!)
+        correctOrder.map((id: number) => prevEvents.find((e) => e.id === id)!)
       );
-
       setFlippedCards(false);
-
-      // Flip cards after a short delay
-      setTimeout(() => {
-        setFlippedCards(true);
-      }, 300);
+      setTimeout(() => setFlippedCards(true), 300);
     }, 300);
-
     setFinalMessage(`${scoreMessage[0]}... You scored ${score} points. See you tomorrow!`);
   };
 
   return (
     <DndProvider backend={HTML5Backend}>
       <div className="game-board-container">
+        {/* TOP-RIGHT CORNER DIFFICULTY INDICATOR */}
+        <div className="difficulty-indicator">
+          Mode: {difficulty === "hard" ? "Hard" : "Easy"}
+        </div>
+
         {loading ? (
           <div className="loading-spinner"></div>
         ) : errorMessage ? (
@@ -138,6 +151,7 @@ const GameBoard: React.FC = () => {
           <>
             {!submitted && <h2>Reorder the Events described on the cards</h2>}
             {submitted && !modalOpen && finalMessage && <h2>{finalMessage}</h2>}
+
             <div className="game-board">
               {showCards &&
                 events.map((event, index) => (
@@ -149,7 +163,7 @@ const GameBoard: React.FC = () => {
                     flipped={flippedCards}
                     cardResults={cardResults}
                     submitted={submitted}
-                    difficulty={difficulty} 
+                    difficulty={difficulty}
                   />
                 ))}
             </div>
@@ -199,7 +213,7 @@ const GameBoard: React.FC = () => {
         </div>
       </Modal>
     </DndProvider>
-  );  
+  );
 };
 
 export default GameBoard;

--- a/frontend/src/components/ToggleSwitch.css
+++ b/frontend/src/components/ToggleSwitch.css
@@ -1,0 +1,59 @@
+/* ToggleSwitch.css */
+
+/* Container for the switch */
+.switch {
+    position: relative;
+    display: inline-block;
+    width: 50px;
+    height: 28px;
+  }
+  
+  /* Hide the real checkbox */
+  .switch input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+    cursor: pointer;
+  }
+  
+  /* The slider/track */
+  .slider {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #ccc; /* Off-state color */
+    transition: 0.4s;
+    border-radius: 34px;
+  }
+  
+  /* The knob/circle */
+  .slider:before {
+    position: absolute;
+    content: "";
+    height: 22px;
+    width: 22px;
+    left: 3px;
+    bottom: 3px;
+    background-color: #fff;
+    transition: 0.4s;
+    border-radius: 50%;
+  }
+  
+  /* When checked, move knob to the right & update track color */
+  input:checked + .slider {
+    background-color: #646cff; /* On-state color */
+  }
+  input:checked + .slider:before {
+    transform: translateX(22px);
+  }
+  
+  /* Optional 'round' styling for the track */
+  .slider.round {
+    border-radius: 34px;
+  }
+  .slider.round:before {
+    border-radius: 50%;
+  }
+  

--- a/frontend/src/components/ToggleSwitch.tsx
+++ b/frontend/src/components/ToggleSwitch.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import "./ToggleSwitch.css";
+
+type ToggleSwitchProps = {
+  isChecked: boolean;
+  onToggle: () => void;
+  label?: string;
+};
+
+const ToggleSwitch: React.FC<ToggleSwitchProps> = ({ isChecked, onToggle, label }) => {
+  return (
+    <div className="toggle-wrapper">
+      <label className="switch">
+        <input
+          type="checkbox"
+          checked={isChecked}
+          onChange={onToggle}
+        />
+        <span className="slider round"></span>
+      </label>
+
+      {/* If a label is passed, show it next to the toggle */}
+      {label && (
+        <span className="toggle-label" style={{ marginLeft: "10px" }}>
+          {label}
+        </span>
+      )}
+    </div>
+  );
+};
+
+export default ToggleSwitch;


### PR DESCRIPTION
- Renames 'difficult' references to 'hard' in backend config/routes.
- Introduces a new ToggleSwitch component for selecting difficulty in App.
- Moves difficulty logic to App, passing it as a prop to GameBoard.
- Adds a top-right corner indicator in GameBoard showing the current mode.
- Updates styling and improves clarity of the difficulty interaction flow.