### PR TITLE
chore: prepare frontend for production

### DIFF
--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -10,7 +10,7 @@ i18n
   .init({
     fallbackLng: 'en',
     supportedLngs: ['en', 'el'],
-    debug: true,
+    debug: import.meta.env.DEV,
     interpolation: { escapeValue: false },
     backend: {
       loadPath: '/locales/{{lng}}.json',

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,1 +1,10 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+    readonly PROD: boolean;
+    readonly DEV: boolean;
+  }
+  
+  interface ImportMeta {
+    readonly env: ImportMetaEnv;
+  }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,25 +1,30 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
+/// <reference types="vite/client" />
+
 export default defineConfig({
-  plugins: [react()], // React plugin for Vite
+  plugins: [react()],
   server: {
-    port: 4173, // Set the development server to use port 4173
-    host: "0.0.0.0", // Expose the server to all network interfaces (important for Docker)
+    port: 4173,
+    host: "0.0.0.0",
     watch: {
-      usePolling: false, // for Ubuntu
+      usePolling: false,
     },
   },
   preview: {
-    port: 4173, // Keep the preview server on 4173
-    host: "0.0.0.0", // Ensure it's accessible from Docker
+    port: 4173,
+    host: "0.0.0.0",
     allowedHosts: [
       'chronoquest-frontend',
       'chronoquest-backend'
     ],
   },
   build: {
-    outDir: 'dist', // Output directory for the production build
-    emptyOutDir: true, // Clear the output directory before building
+    outDir: 'dist',
+    emptyOutDir: true,
   },
+  esbuild: {
+    drop: process.env.NODE_ENV === "production" ? ["console"] : [],
+  }  
 });


### PR DESCRIPTION
- Disable i18next debug logging in production
- Remove console logs in production using esbuild
- Add TypeScript definitions for import.meta.env
- Clean up comments and formatting in vite.config.ts