### PR TITLE
feat: Optimize image storage: Ignore /public/images & prepare for external hosting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ dist/
 **/.dockerignore
 .vscode/
 backend/cookies.txt
+
+backend/public/images/*
+!public/images/.gitkeep 

--- a/backend/migrations/001-create-events.sql
+++ b/backend/migrations/001-create-events.sql
@@ -8,10 +8,10 @@ CREATE TABLE IF NOT EXISTS events (
   location VARCHAR(255) NOT NULL,
   description_en TEXT,
   description_el TEXT,
-  imageUrl VARCHAR(255) NOT NULL,
+  image_path VARCHAR(255) NOT NULL,
   riddle_en TEXT,
   riddle_el TEXT,
-  wikipediaUrl TEXT,
+  wikipedia_url TEXT,
   details_en TEXT,
   details_el TEXT
 );

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -3,6 +3,7 @@ import cors from "cors";
 import cookieParser from "cookie-parser";
 import eventRoutes from "./routes/events";
 import gameAttemptsRoutes from "./routes/gameAttempts";
+import path from 'path';
 
 const app = express();
 
@@ -22,6 +23,9 @@ app.use(cors({
 app.use(express.json());
 app.use(cookieParser());
 
+// ✅ Serve images from the public folder
+app.use("/images", express.static(path.join(__dirname, "../public/images")));
+
 // Root route
 app.get("/", (req, res) => {
   res.send("Welcome to the ChronoQuest Backend API");
@@ -34,4 +38,5 @@ app.use("/api/game", gameAttemptsRoutes);
 const port = process.env.PORT || 5000;
 app.listen(port, () => {
   console.log(`Server is running on http://localhost:${port}`);
+  console.log(`Serving images from http://localhost:${port}/images/`);
 });

--- a/backend/src/routes/events.ts
+++ b/backend/src/routes/events.ts
@@ -33,7 +33,12 @@ router.get('/', async (req, res) => {
     }
 
     const result = await pool.query(query, params);
-    res.json({ level, events: result.rows });
+
+    const events = result.rows.map(event => ({
+      ...event,
+      image_path: `http://localhost:5000/images/${event.image_path}`,
+    }));
+    res.json({ level, events });
   } catch (error) {
     console.error('Error fetching events:', error);
     res.status(500).json({ error: 'Failed to fetch events' });
@@ -42,11 +47,11 @@ router.get('/', async (req, res) => {
 
 // POST /events - create a new event
 router.post('/', async (req, res) => {
-  const { name, date, location, description, imageUrl } = req.body;
+  const { name, date, location, description, image_path } = req.body;
   try {
     const result = await pool.query(
-      'INSERT INTO events (name, date, location, description, imageUrl) VALUES ($1, $2, $3, $4, $5) RETURNING *',
-      [name, date, location, description, imageUrl]
+      'INSERT INTO events (name, date, location, description, image_path) VALUES ($1, $2, $3, $4, $5) RETURNING *',
+      [name, date, location, description, image_path]
     );
     res.status(201).json(result.rows[0]);
   } catch (error) {

--- a/backend/src/seed.ts
+++ b/backend/src/seed.ts
@@ -4,7 +4,7 @@ async function seed() {
   try {
     const result = await pool.query(`
       INSERT INTO events 
-        (name_en, name_el, date, location, description_en, description_el, imageUrl, riddle_en, riddle_el, wikipediaUrl, details_en, details_el)
+        (name_en, name_el, date, location, description_en, description_el, image_path, riddle_en, riddle_el, wikipedia_url, details_en, details_el)
       VALUES
         (
           'End of the First Punic War',
@@ -13,7 +13,7 @@ async function seed() {
           'Mediterranean Sea',
           'Rome defeated Carthage in 241 BCE, securing control over Sicily and ending the First Punic War.',
           'Η Ρώμη νίκησε την Καρχηδόνα το 241 π.Χ., εξασφαλίζοντας τον έλεγχο της Σικελίας και τερματίζοντας τον Πρώτο Καρχηδονιακό Πόλεμο.',
-          'https://upload.wikimedia.org/wikipedia/commons/thumb/6/65/Battle_of_Aegates_Islands.jpg/800px-Battle_of_Aegates_Islands.jpg',
+          '03_10_first_punic_war_ends.jpg',
           'A decisive naval battle ended the first long war between two ancient powers.',
           'Μια αποφασιστική ναυμαχία έληξε τον πρώτο μεγάλο πόλεμο μεταξύ δύο αρχαίων δυνάμεων.',
           'https://en.wikipedia.org/wiki/Battle_of_the_Aegates',
@@ -27,7 +27,7 @@ async function seed() {
           'Boston, USA',
           'Alexander Graham Bell made the first successful phone call, revolutionizing global communication.',
           'Ο Alexander Graham Bell πραγματοποίησε την πρώτη επιτυχημένη τηλεφωνική κλήση, αλλάζοντας την παγκόσμια επικοινωνία.',
-          'https://www.protagon.gr/wp-content/uploads/2018/03/F4-GrahamBell.jpg',
+          '03_10_first_phone_call_bell.webp',
           'A call that rang out across the world bridging voices across hidden wires.',
           'Μια κλήση που αντήχησε σε όλο τον κόσμο γεφυρώνοντας φωνές μέσω κρυμμένων καλωδίων.',
           'https://en.wikipedia.org/wiki/History_of_the_telephone',
@@ -41,7 +41,7 @@ async function seed() {
           'Tokyo, Japan',
           'U.S. bombers firebombed Tokyo, killing over 100,000 people, the deadliest air raid in history.',
           'Αμερικανικά βομβαρδιστικά έκαψαν το Τόκιο, σκοτώνοντας πάνω από 100.000 άτομα, στη φονικότερη αεροπορική επιδρομή της ιστορίας.',
-          'https://upload.wikimedia.org/wikipedia/commons/thumb/8/84/Tokyo_1945-3-10-1.jpg/1280px-Tokyo_1945-3-10-1.jpg',
+          '03_10_tokyo_firebombing.jpg',
           'The most destructive single air attack in human history.',
           'Η πιο καταστροφική μεμονωμένη αεροπορική επίθεση στην ανθρώπινη ιστορία.',
           'https://en.wikipedia.org/wiki/Bombing_of_Tokyo',
@@ -55,7 +55,7 @@ async function seed() {
           'Lhasa, Tibet',
           'Tibetans rose against Chinese rule, leading to the Dalai Lama''s exile to India.',
           'Οι Θιβετιανοί εξεγέρθηκαν ενάντια στην κινεζική κυριαρχία, οδηγώντας τον Δαλάι Λάμα στην εξορία στην Ινδία.',
-          'https://ichef.bbci.co.uk/images/ic/640x360/p0162mb2.jpg',
+          '03_10_tibetan_uprising.webp',
           'A people of high peaks and deep traditions rose but lost its leader to exile.',
           'Ένας λαός των υψηλών κορυφών και βαθιών παραδόσεων ξεσηκώθηκε αλλά έχασε τον ηγέτη του στην εξορία.',
           'https://en.wikipedia.org/wiki/1959_Tibetan_uprising',
@@ -69,7 +69,7 @@ async function seed() {
           'Solar System',
           'Planetary alignment had sparked doomsday predictions, but nothing catastrophic occurred.',
           'Η ευθυγράμμιση των πλανητών προκάλεσε προβλέψεις καταστροφής, αλλά τίποτα καταστροφικό δεν συνέβη.',
-          'https://upload.wikimedia.org/wikipedia/en/e/e7/The_Jupiter_Effect.jpg',
+          '03_10_jupiter_effect.webp',
           'Maybe the First “Scientific” Doomsday Prediction, planets aligned, but the world stayed still.',
           'Ίσως η πρώτη «επιστημονική» πρόβλεψη καταστροφής, οι πλανήτες ευθυγραμμίστηκαν, αλλά ο κόσμος παρέμεινε ίδιος.',
           'https://en.wikipedia.org/wiki/Jupiter_Effect',
@@ -77,13 +77,13 @@ async function seed() {
           'Λεπτομέρειες για την Επίδραση του Δία'
         ),
         (
-          'Roman Empire Bars Jews from Public Office',
+          'Roman Empire Bans Jews from Public Office',
           'Η Ρωμαϊκή Αυτοκρατορία Απαγορεύει στους Εβραίους Δημόσια Αξιώματα',
           '418-03-10 00:00:00',
           'Δυτική Ρωμαϊκή Αυτοκρατορία',
           'In 418 AD, the Christianised Roman Empire barred Jews from public office, reinforcing its shift to Christian dominance.',
           'Το 418 μ.Χ., η χριστιανοποιημένη Ρωμαϊκή Αυτοκρατορία απαγόρευσε στους Εβραίους να κατέχουν δημόσια αξιώματα, ενισχύοντας τη στροφή της προς τη χριστιανική κυριαρχία.',
-          'https://www.heritage-history.com/books/church/jerusalem/zpage121.gif',
+          '03_10_jews_ban_from_office.jpg',
           'A powerful empire barred a religious minority from holding public office.',
           'Μια ισχυρή αυτοκρατορία απαγόρευσε σε μια θρησκευτική μειονότητα να κατέχει δημόσια αξιώματα.',
           'https://en.wikipedia.org/wiki/History_of_the_Jews_in_the_Roman_Empire',
@@ -97,7 +97,7 @@ async function seed() {
           'Γαλλία',
           'In 1831, France established the Foreign Legion, recruiting soldiers from around the world for military service.',
           'Το 1831, η Γαλλία ίδρυσε τη Λεγεώνα των Ξένων, στρατολογώντας στρατιώτες από όλο τον κόσμο για στρατιωτική θητεία.',
-          'https://fr.wikipedia.org/wiki/L%C3%A9gion_%C3%A9trang%C3%A8re#/media/Fichier:L%C3%A9gion_%C3%A9trang%C3%A8re_et_tirailleurs_indig%C3%A8nes.jpg',
+          '03_10_legion_etrangere.png',
           'A band of outcasts, warriors, and wanderers found a new flag to fight for.',
           'Μια ομάδα απόκληρων, πολεμιστών και περιπλανώμενων βρήκε μια νέα σημαία για να πολεμήσει.',
           'https://en.wikipedia.org/wiki/French_Foreign_Legion',
@@ -111,11 +111,11 @@ async function seed() {
           'Ηνωμένες Πολιτείες',
           'The dot-com bubble peaked, leading to the collapse of tech stocks and a burst in the internet market.',
           'Η φούσκα των dot-com έφτασε στην κορυφή, οδηγώντας στην κατάρρευση των μετοχών της τεχνολογίας και στην έκρηξη της αγοράς του διαδικτύου.',
-          'https://moneymorning.com/wp-content/blogs.dir/1/files/2015/06/shutterstock_162413930.jpg',
+          '03_10_dot_com_bubble.webp',
           'Click, invest, peak before collapse.',
           'Κλικ, επένδυση, κορύφωση πριν την κατάρρευση.',
           'https://en.wikipedia.org/wiki/Dot-com_bubble',
-          'The dot-com bubble details',
+          'The dot-com bubble peaked, leading to the collapse of tech stocks and a burst in the internet market. The dot-com bubble peaked, leading to the collapse of tech stocks and a burst in the internet market. The dot-com bubble peaked, leading to the collapse of tech stocks and a burst in the internet market. The dot-com bubble peaked, leading to the collapse of tech stocks and a burst in the internet market. The dot-com bubble peaked, leading to the collapse of tech stocks and a burst in the internet market. The dot-com bubble peaked, leading to the collapse of tech stocks and a burst in the internet market. The dot-com bubble peaked, leading to the collapse of tech stocks and a burst in the internet market.',
           'Λεπτομέρειες για τη Φούσκα του Διαδικτύου'
         ),
         (
@@ -125,7 +125,7 @@ async function seed() {
           'Κούβα',
           'General Batista led a coup in Cuba, overthrowing the government and establishing a dictatorship, sparking the Cuban Revolution.',
           'Ο στρατηγός Μπατίστα ηγήθηκε πραξικοπήματος στην Κούβα, ανατρέποντας την κυβέρνηση και εγκαθιστώντας δικτατορία, πυροδοτώντας την Κουβανική Επανάσταση.',
-          'https://upload.wikimedia.org/wikipedia/commons/thumb/9/99/BatistaDC1938.jpg/280px-BatistaDC1938.jpg',
+          '03_10_batista_cuba_coup.jpg',
           'A military leader overthrew the government, setting the stage for revolution.',
           'Ένας στρατιωτικός ηγέτης ανέτρεψε την κυβέρνηση, προετοιμάζοντας το έδαφος για την επανάσταση.',
           'https://en.wikipedia.org/wiki/Fulgencio_Batista',
@@ -139,7 +139,7 @@ async function seed() {
           'Ηνωμένες Πολιτείες',
           'Simon & Garfunkel recorded "The Sound of Silence," which became an iconic anthem of the 1960s.',
           'Οι Simon & Garfunkel ηχογράφησαν το "The Sound of Silence," το οποίο έγινε εμβληματικός ύμνος της δεκαετίας του 1960.',
-          'https://68.media.tumblr.com/1ea0e0b9974786565c97e5bf57f8b641/tumblr_ol33ik4TiG1snb6qwo1_1280.jpg',
+          'backend/public03_10_sound_of_silence.jpg',
           'Hello darkness, my old friend.',
           'Hello darkness, my old friend.',
           'https://en.wikipedia.org/wiki/The_Sound_of_Silence',

--- a/frontend/public/locales/en.json
+++ b/frontend/public/locales/en.json
@@ -17,7 +17,7 @@
     "history_enthusiast": "History Enthusiast",
     "history_enthusiast_desc": "Well done! You're developing a keen historical sense. \nA little more practice, and you'll be placing events like a pro!\n",
     "history_explorer": "History Explorer",
-    "history_explorer_desc": "You're on your way!\nHistory is vast and complex, and every\n attempt sharpens your skills.\nKeep playing and learning!\n",
+    "history_explorer_desc": "You're on your way!\nHistory is vast and complex, and every attempt sharpens your skills.\nKeep playing and learning!\n",
     "time_traveler_training": "Time Traveler in Training",
     "time_traveler_training_desc": "Don't be discouraged!\nEven the greatest historians had to start somewhere.\nKeep plnaying, and history will reveal its patterns to you!\n",
     "close": "Close",

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -13,10 +13,10 @@ interface CardProps {
     date: string;
     description_en: string;
     description_el: string;
-    imageurl: string;
+    image_path: string;
     riddle_en: string;
     riddle_el: string;
-    wikipediaurl: string;
+    wikipedia_url: string;
     details_en: string;
     details_el: string;
   };
@@ -87,7 +87,7 @@ const Card: React.FC<CardProps> = ({ event, index, moveCard, flipped, cardResult
           
           <div className={`card-content`}>
               <img 
-                src={event.imageurl} 
+                src={event.image_path} 
                 alt={String(eventName)} 
                 className="card-image"
               />

--- a/frontend/src/components/GameBoard.tsx
+++ b/frontend/src/components/GameBoard.tsx
@@ -24,10 +24,10 @@ const GameBoard: React.FC<GameBoardProps> = ({ difficulty }) => {
     date: string;
     description_en: string;
     description_el: string;
-    imageurl: string;
+    image_path: string;
     riddle_en: string;
     riddle_el: string;
-    wikipediaurl: string;
+    wikipedia_url: string;
     details_en: string;
     details_el: string;
   }>>([]);
@@ -346,8 +346,7 @@ const GameBoard: React.FC<GameBoardProps> = ({ difficulty }) => {
                 const eventName = selectedEvent[`name_${lang}` as keyof typeof event] || selectedEvent.name_en;
                 const eventDescription = selectedEvent[`description_${lang}` as keyof typeof selectedEvent] || selectedEvent.description_en;
                 const eventDetails = selectedEvent[`details_${lang}` as keyof typeof selectedEvent] || selectedEvent.details_en;
-                const eventWikiUrl = selectedEvent.wikipediaurl;
-
+                const eventWikiUrl = selectedEvent.wikipedia_url;
 
                 return (
                   <>
@@ -357,7 +356,7 @@ const GameBoard: React.FC<GameBoardProps> = ({ difficulty }) => {
                       <p><strong>{t("year")}: </strong>{formatDate(selectedEvent.date)}</p>
                     </div>
                     <img
-                      src={selectedEvent.imageurl}
+                      src={selectedEvent.image_path}
                       alt={eventName}
                     />
                     <div className="modal-event-content-down">
@@ -372,7 +371,6 @@ const GameBoard: React.FC<GameBoardProps> = ({ difficulty }) => {
                           {t("read_more")}
                         </a>
                       </span>
-                      {/* <span> The dot-com bubble peaked, leading to the collapse of tech stocks and a burst in the internet market. The dot-com bubble peaked, leading to the collapse of tech stocks and a burst in the internet market. The dot-com bubble peaked, leading to the collapse of tech stocks and a burst in the internet market. The dot-com bubble peaked, leading to the collapse of tech stocks and a burst in the internet market. The dot-com bubble peaked, leading to the collapse of tech stocks and a burst in the internet market. The dot-com bubble peaked, leading to the collapse of tech stocks and a burst in the internet market. The dot-com bubble peaked, leading to the collapse of tech stocks and a burst in the internet market. <br/>  */}
                     </div>
                     <div className="close-btn-container">
                       <button className="close-btn" onClick={closeEventModal}>

--- a/frontend/src/types/eventTypes.ts
+++ b/frontend/src/types/eventTypes.ts
@@ -5,10 +5,10 @@ export interface EventType {
     date: string;
     description_en: string;
     description_el: string;
-    imageurl: string;
+    image_path: string;
     riddle_en: string;
     riddle_el: string;
-    wikipediaurl: string;
+    wikipedia_url: string;
     details_en: string;
     details_el: string;
   }


### PR DESCRIPTION
- Added /public/images/* to .gitignore to prevent large files in Git
- Kept /public/images/.gitkeep to ensure the folder exists
- Updated backend API to serve images dynamically
- Suggested external storage solutions for scalability