### PR TITLE
fix : Image url env fallback

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -28,14 +28,14 @@ app.use(cors({
             callback(new Error("Not allowed by CORS"));
         }
     },
-    credentials: true // ⬅️ Allow cookies and authentication headers
+    credentials: true // Allow cookies and authentication headers
 }));
 
 app.use(express.json());
 app.use(cookieParser());
 
-// ✅ Serve images from the public folder
-app.use("/api/images", express.static(path.join(__dirname, "../shared/images")));
+// Serve images from the public folder
+app.use("/images", express.static(path.join(__dirname, "../shared/images")));
 
 // Root route
 app.get("/", (req, res) => {

--- a/backend/src/routes/events.ts
+++ b/backend/src/routes/events.ts
@@ -7,7 +7,7 @@ import dotenv from 'dotenv';
 
 dotenv.config();
 
-const PUBLIC_URL = process.env.PUBLIC_URL || 'http://localhost:4173';
+const PUBLIC_URL = process.env.PUBLIC_URL || `${process.env.PROTOCOL}://${process.env.DOMAIN}` || 'http://localhost:4173';
 
 const router = Router();
 
@@ -48,7 +48,7 @@ router.get('/', async (req, res) => {
     // Build full image path using the dynamic BACKEND_URL
     const events = result.rows.map(event => ({
       ...event,
-      image_path: `${PUBLIC_URL}/api/images/${event.image_path}`,
+      image_path: `${PUBLIC_URL}/images/${event.image_path}`,
     }));
 
     res.json({ level, events });


### PR DESCRIPTION
…al environments

- Changed image static route from /api/images to /images in Express
- Adjusted PUBLIC_URL fallback logic to use PROTOCOL and DOMAIN from .env
- Ensured image paths work correctly across environments