### PR TITLE
fix: Improve local dev setup with dynamic HMR and add Greek 'play again' translation

### DIFF
--- a/frontend/public/locales/el.json
+++ b/frontend/public/locales/el.json
@@ -42,6 +42,7 @@
     "bce": "π.Χ.",
     "read_more": "Μάθε περισσσότερα",
     "year": "Χρονιά",
+    "play_again": "Ξαναπαίξε",
     "remaining_attempts_one": "Απομένει {{count}} προσπάθεια σήμερα",
     "remaining_attempts_other": "Απομένουν {{count}} προσπάθειες σήμερα"
   }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -14,9 +14,9 @@ export default defineConfig(({ mode }) => {
       host: '0.0.0.0',
       port: 4173,
       hmr: {
-        protocol: 'wss',
+        protocol: env.VITE_PUBLIC_URL.startsWith("https") ? "wss" : "ws",
         host: hostname,
-        clientPort: 443,
+        clientPort: env.VITE_PUBLIC_URL.startsWith("https") ? 443 : 4173,
       },
       allowedHosts: [
         hostname,


### PR DESCRIPTION


- Updated vite.config.ts to dynamically select ws/wss and port based on VITE_PUBLIC_URL
- Added missing Greek translation key: 'play_again'