### PR TITLE
fix: Reverse card display order on mobile portrait layouts

### DIFF
--- a/frontend/src/components/GameBoard.css
+++ b/frontend/src/components/GameBoard.css
@@ -120,8 +120,8 @@
   flex-direction: column;
   align-items: center;
   justify-content: space-between;
-  pointer-events: none; /* ⬅️ allows drag interactions to go through */
-  background: transparent; /* ⬅️ optional, can be semi-transparent if you like */
+  pointer-events: none;
+  background: transparent;
   z-index: 2;
 }
 
@@ -416,7 +416,7 @@
 /* Mobile (Taller) Portrait */
 @media (max-width: 480px) and (min-height: 668px) and (orientation: portrait) {
   .game-board {
-    flex-direction: column;
+    flex-direction: column-reverse;
     gap: clamp(-30px, 2vw, 5px);
     height: 76vh;
   }
@@ -464,7 +464,7 @@
 /* Mobile (Compact) Portrait */
 @media (max-width: 400px) and (orientation: portrait) {
   .game-board {
-    flex-direction: column;
+    flex-direction: column-reverse;
     gap: clamp(0px, 10px, 15px);
   }
   .game-board-container {
@@ -508,7 +508,7 @@
 /* iPad / Tablet Portrait */
 @media (min-width: 480px)  and (max-width: 1424px) and (min-aspect-ratio: 3/5)  and (orientation: portrait) {
   .game-board {
-    flex-direction: column;
+    flex-direction: column-reverse;
     height: 68vh;
     gap: 1vh;
     overflow: visible;

--- a/frontend/src/components/GameBoard.tsx
+++ b/frontend/src/components/GameBoard.tsx
@@ -264,9 +264,9 @@ const GameBoard: React.FC<GameBoardProps> = ({ difficulty, hintUsed, toBlink, su
               </div>
 
               <div className="vertical-axis">
-                <span className="axis-label oldest">{t("oldest_event")}</span>
-                <div className="axis-line"></div>
                 <span className="axis-label most-recent">{t("most_recent_event")}</span>
+                  <div className="axis-line"></div>
+                <span className="axis-label oldest">{t("oldest_event")}</span> 
               </div>
             </div>
             


### PR DESCRIPTION
- Changed flex-direction to column-reverse for better chronological alignment on small screens
- Updated vertical axis label order to match new card direction
- Applied consistent layout behavior across mobile and tablet portrait breakpoints