### PR TITLE
chore: Add multi-stage Docker build and environment-aware frontend hadling

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - ./shared:/app/shared
       - /app/backend/node_modules
     environment:
-      - NODE_ENV=production
+      - NODE_ENV=${NODE_ENV}
       - DATABASE_URL=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
       - BASE_URL=${PROTOCOL}://${DOMAIN}:5000
     env_file:
@@ -45,13 +45,13 @@ services:
       context: .
       dockerfile: frontend/Dockerfile
     ports:
-      - "4173:4173"
+      - "4173:80"
     volumes:
       - ./frontend:/app
       - ./shared:/app/shared
       - /app/node_modules
     environment:
-      - NODE_ENV=production
+      - NODE_ENV=${NODE_ENV}
       - VITE_API_BASE_URL=${VITE_API_BASE_URL}
     env_file:
       - .env

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,21 +1,31 @@
-FROM node:18
-
+# Accept the build arg
+ARG MODE=production
+# or MODE=development
+FROM node:18 as base
 WORKDIR /app
 
-# Copy package.json first for better caching
+# Copy and install deps
 COPY frontend/package*.json ./
-
 RUN npm install
 
-# Copy the frontend source code
+# Copy source
 COPY frontend/ ./
-
-# Copy shared folder
 COPY shared /app/shared
+COPY .env .env
 
-# Expose your preferred port (4173)
+# ---------- DEV Stage ----------
+FROM base as development
 EXPOSE 4173
-
-# Start Vite in development mode with port 4173
 CMD ["node", "node_modules/vite/bin/vite.js", "--host", "0.0.0.0", "--port", "4173"]
 
+# ---------- PROD Stage ----------
+FROM base as builder
+RUN npm run build
+
+FROM nginx:alpine as production
+COPY --from=builder /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]
+
+# ---------- Final Stage Dispatcher ----------
+FROM ${MODE} as final


### PR DESCRIPTION
- Introduced ARG-based build mode (MODE) to Dockerfile with base, development, builder, and production stages
- Ensured NODE_ENV is passed via docker-compose from .env
- Changed frontend port mapping from 4173:4173 to 4173:80 for better consistency with NGINX production setup
- Enabled conditional image dispatching for dev and prod flows