### PR TITLE
chore: Add dynamic Docker build stages based on MODE argument from docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,8 @@ services:
     build:
       context: .
       dockerfile: frontend/Dockerfile
+      args:
+        - MODE=${NODE_ENV}
     ports:
       - "4173:80"
     volumes:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,31 +1,35 @@
-# Accept the build arg
-ARG MODE=production
-# or MODE=development
-FROM node:18 as base
+# ---------- Declare arg for mode ----------
+ARG MODE
+
+# ---------- Base Stage ----------
+FROM node:18 AS base
 WORKDIR /app
 
-# Copy and install deps
 COPY frontend/package*.json ./
 RUN npm install
 
-# Copy source
 COPY frontend/ ./
 COPY shared /app/shared
 COPY .env .env
 
 # ---------- DEV Stage ----------
-FROM base as development
+FROM base AS development
+RUN echo "🏗️  Building DEVELOPMENT image"
 EXPOSE 4173
 CMD ["node", "node_modules/vite/bin/vite.js", "--host", "0.0.0.0", "--port", "4173"]
 
 # ---------- PROD Stage ----------
-FROM base as builder
-RUN npm run build
+FROM base AS builder
+RUN echo "🏗️  Building PRODUCTION builder image" \
+    && npm run build
 
-FROM nginx:alpine as production
+FROM nginx:alpine AS production
+RUN echo "🏗️  Building PRODUCTION final image"
 COPY --from=builder /app/dist /usr/share/nginx/html
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]
 
 # ---------- Final Stage Dispatcher ----------
-FROM ${MODE} as final
+FROM ${MODE} AS final
+ARG MODE
+RUN echo "🏗️  Building FINAL image for mode: ${MODE}"    


### PR DESCRIPTION
- Enables switching between development and production modes using NODE_ENV
- Adds echo statements for clearer stage diagnostics
- Restructures Dockerfile to isolate base, dev, builder, and production logic